### PR TITLE
[release/v2.12] Bump rancher-turtles to v0.23.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 webhookVersion: 107.0.1+up0.8.1
 remoteDialerProxyVersion: 106.0.1+up0.5.0
 provisioningCAPIVersion: 107.0.0+up0.8.0
-turtlesVersion: 107.0.0+up0.22.0
+turtlesVersion: 107.0.1+up0.23.0
 cspAdapterMinVersion: 107.0.0+up7.0.0
 defaultShellVersion: rancher/shell:v0.5.0
 fleetVersion: 107.0.1+up0.13.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,8 +7,8 @@ const (
 	DefaultSccOperatorImage  = "rancher/scc-operator:v0.1.1"
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "107.0.1+up0.13.1"
-	TurtlesVersion           = "107.0.0+up0.22.0"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"
 	RemoteDialerProxyVersion = "106.0.1+up0.5.0"
+	TurtlesVersion           = "107.0.1+up0.23.0"
 	WebhookVersion           = "107.0.1+up0.8.1"
 )


### PR DESCRIPTION
# Release note for [v0.23.0](https://github.com/rancher/turtles/releases/tag/v0.23.0)

<!-- Release notes generated using configuration in .github/release.yaml at v0.23.0-rc.0 -->

Rancher Turtles is an extension to Rancher that brings full Cluster API integration to Rancher.

This release introduces a new opt-in feature to allow automatic CAPIProvider updates.  
A new option has been added `CAPIProvider.spec.enableAutomaticUpdate`.  
The providers installed with the Turtles chart will continue to be automatically updated. However, if you installed custom providers and you relied on the empty `version` field for automatic updates, you have now to explicitly set the `enableAutomaticUpdate: true` flag.

Additionally, the caprke2 version has been updated to latest (0.19.0).

## What's Changed
### 🐛 Bugs
* Wait for ASO pod to be ready and restart if needed by @alexander-demicev in https://github.com/rancher/turtles/pull/1596
* fix: Make post-upgrade hook idempotent by @yiannistri in https://github.com/rancher/turtles/pull/1595
* Fix CAPIProvider credentials syncing by @anmazzotti in https://github.com/rancher/turtles/pull/1594
* Implement CAPIProvider EnableAutomaticUpdate toggle by @anmazzotti in https://github.com/rancher/turtles/pull/1601
### 📖 Docs
* Bump Turtles and Rancher versions for quickstart by @mjura in https://github.com/rancher/turtles/pull/1600
### Other Changes
* feat: Add post-upgrade hook that deletes all CAPI Operator provider resources by @yiannistri in https://github.com/rancher/turtles/pull/1582
* chore(deps): Bump github.com/spf13/pflag from 1.0.6 to 1.0.7 in /examples in the other-dependencies group by @dependabot[bot] in https://github.com/rancher/turtles/pull/1561
* chore(deps): Bump the other-dependencies group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/rancher/turtles/pull/1577
* chore(deps): Bump the other-dependencies group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/rancher/turtles/pull/1578
* chore(deps): Bump the other-dependencies group across 1 directory with 4 updates by @dependabot[bot] in https://github.com/rancher/turtles/pull/1588
* chore(deps): Bump github.com/onsi/gomega from 1.37.0 to 1.38.0 in the testing-dependencies group by @dependabot[bot] in https://github.com/rancher/turtles/pull/1574
* chore(deps): Bump the other-dependencies group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/rancher/turtles/pull/1576
* Actualize updatecli manifest by @anmazzotti in https://github.com/rancher/turtles/pull/1599
* chore(deps): Bump rancher/aws-janitor from 0.1.0 to 0.2.0 by @dependabot[bot] in https://github.com/rancher/turtles/pull/1607
* test: Update test to verify that CAPI Operator provider resources have been removed by @yiannistri in https://github.com/rancher/turtles/pull/1605
* chore(deps): Bump golang.org/x/text from 0.27.0 to 0.28.0 in the other-dependencies group by @dependabot[bot] in https://github.com/rancher/turtles/pull/1606
* chore(deps): Bump actions/checkout from 4 to 5 by @dependabot[bot] in https://github.com/rancher/turtles/pull/1622
* Bump to caprke2 0.19 by @anmazzotti in https://github.com/rancher/turtles/pull/1624
* Use latest ngrok-operator version for dev env by @anmazzotti in https://github.com/rancher/turtles/pull/1642
* chore(deps): Bump github.com/go-viper/mapstructure/v2 from 2.3.0 to 2.4.0 in /test by @dependabot[bot] in https://github.com/rancher/turtles/pull/1640
* Create separate providers chart by @anmazzotti in https://github.com/rancher/turtles/pull/1632


**Full Changelog**: https://github.com/rancher/turtles/compare/v0.22.0...v0.23.0

# Useful links

- Commit comparison: https://github.com/rancher/turtles/compare/v0.22.0...v0.23.0
- Release v0.22.0: https://github.com/rancher/turtles/releases/tag/v0.22.0

# About this PR

The workflow was triggered by furkatgofurov7.