### PR TITLE
[release/v2.12] Bump rancher-turtles to v0.19.0-rc.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 webhookVersion: 107.0.1+up0.8.1
 remoteDialerProxyVersion: 106.0.1+up0.5.0
 provisioningCAPIVersion: 107.0.0+up0.8.0
-turtlesVersion: 106.0.1+up0.19.0-rc.0
+turtlesVersion: 106.0.1+up0.19.0-rc.1
 cspAdapterMinVersion: 107.0.0+up7.0.0
 defaultShellVersion: rancher/shell:v0.5.0
 fleetVersion: 107.0.1+up0.13.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,8 +7,8 @@ const (
 	DefaultSccOperatorImage  = "rancher/scc-operator:v0.1.1"
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "107.0.1+up0.13.1"
-	TurtlesVersion           = "106.0.1+up0.19.0-rc.0"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"
 	RemoteDialerProxyVersion = "106.0.1+up0.5.0"
+	TurtlesVersion           = "106.0.1+up0.19.0-rc.1"
 	WebhookVersion           = "107.0.1+up0.8.1"
 )


### PR DESCRIPTION
# Release note for [v0.19.0-rc.1](https://github.com/furkatgofurov7/rancher-turtles/releases/tag/v0.19.0-rc.1)

<!-- Release notes generated using configuration in .github/release.yaml at release-0.19 -->
Test v0.19.0-rc.1 release


**Full Changelog**: https://github.com/furkatgofurov7/rancher-turtles/commits/v0.19.0-rc.1

# Useful links

- Commit comparison: https://github.com/furkatgofurov7/rancher-turtles/compare/v0.19.0-rc.0...v0.19.0-rc.1
- Release v0.19.0-rc.0: https://github.com/furkatgofurov7/rancher-turtles/releases/tag/v0.19.0-rc.0

# About this PR

The workflow was triggered by furkatgofurov7.